### PR TITLE
Support obfuscated & shaded JARs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 .gradle/
+/.idea

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ It does three things:
 * Resolves the format string to `"(log4j jndi disabled)"` in the log message
   (to prevent transitive injections).
 
+
+**Note**: _log4j-jndi-be-gone_ does not look at the original Log4J `JndiLookup` class name.
+Instead it utilizes [Classgraph](https://github.com/classgraph/classgraph) to find the culprit classes by
+looking at their internal structure. In particular, it searches for classes that contain a final static string field
+`static final String CONTAINER_JNDI_RESOURCE_PATH_PREFIX` and a `public String lookup(?, String)` method, that both present
+in the `JndiLookup` class. That enables support for obfuscated or shaded _Log4j_ libraries (e.g. fat-jars).
+
 # Usage
 
 Add `-javaagent:path/to/log4j-jndi-be-gone-1.0.0-standalone.jar` to your `java` commands.
@@ -19,8 +26,14 @@ Add `-javaagent:path/to/log4j-jndi-be-gone-1.0.0-standalone.jar` to your `java` 
 ***Note:*** If you already have Byte Buddy in the classpath, try using
 `log4j-jndi-be-gone-1.0.0.jar`.
 
-```
+```shell
 $ java -javaagent:path/to/log4j-jndi-be-gone-1.0.0-standalone.jar -jar path/to/some.jar
+```
+
+You can also enable logging to have a list of intercepted classes.
+
+```shell
+$ java -javaagent:path/to/log4j-jndi-be-gone-1.0.0-standalone.jar=logDir=/tmp/my/logs/ ...
 ```
 
 # Obtaining log4j-jndi-be-gone
@@ -28,14 +41,26 @@ $ java -javaagent:path/to/log4j-jndi-be-gone-1.0.0-standalone.jar -jar path/to/s
 You can build the JAR with `./gradlew` (`build/libs/log4j-jndi-be-gone-1.0.0(-standalone).jar`)
 or get it from the [releases page](https://github.com/nccgroup/log4j-jndi-be-gone/releases).
 
+# Building from source
+
+```shell
+$ ./gradlew
+````
+
+The output JAR file is located in the `$PROJECT_HOME/build/libs/` directory.
+
 # Compatibility
 
 The log4j-jndi-be-gone agent JAR supports Java 6-17+.
 
 # Caveats
 
-* log4j-jndi-be-gone will not work if the log4j library has been obfuscated or
-if its class packages/names have been modified.
+* log4j-jndi-be-gone might not work if the log4j library has been heavily obfuscated.
+
+
+* It might block calls to a benign `lookup` method if the declaring class internal 
+  structure happens to resemble the `JndiLookup` class. (See above).
+
 
 * `log4j-jndi-be-gone-1.0.0-standalone.jar` bundles in Byte Buddy. If you
   already use Byte Buddy, you may run into issues with it. Try

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'trust.nccgroup'
-version = '1.0.0'
+version = '1.0.0-wajda'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
@@ -16,6 +16,7 @@ repositories {
 
 dependencies {
   implementation group: 'net.bytebuddy', name: 'byte-buddy', version: '[1.12.0, 1.13)'
+  implementation group: 'io.github.classgraph', name: 'classgraph', version: '[4.8.138]'
 }
 
 sourceSets {
@@ -74,7 +75,7 @@ publishing {
             from components.java
             pom {
                 name = 'log4j-jndi-be-gone'
-                description = 
+                description =
                 url = 'https://github.com/nccgroup/log4j-jndi-be-gone'
                 licenses {
                     license {

--- a/src/trust/nccgroup/jndibegone/AgentMain.java
+++ b/src/trust/nccgroup/jndibegone/AgentMain.java
@@ -23,7 +23,7 @@ import trust.nccgroup.jndibegone.Agent;
 public class AgentMain {
 
   public static void agentmain(String args, Instrumentation inst) {
-    Agent.load(inst);
+    Agent.load(args, inst);
   }
 
 }

--- a/src/trust/nccgroup/jndibegone/JndiLookupClassFinder.java
+++ b/src/trust/nccgroup/jndibegone/JndiLookupClassFinder.java
@@ -3,7 +3,6 @@ package trust.nccgroup.jndibegone;
 import io.github.classgraph.*;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class JndiLookupClassFinder {
@@ -23,22 +22,22 @@ public class JndiLookupClassFinder {
       new ClassGraph()
         .ignoreFieldVisibility()
         .enableMethodInfo()
+        .enableClassInfo()
         .scan();
 
     try {
-      final List<Class<?>> culpritClasses =
+      final ClassInfoList JndiLookupIshClassInfos =
         scanResult
-          .getAllClasses()
+          .getAllStandardClasses()
           .filter(new ClassInfoList.ClassInfoFilter() {
             public boolean accept(ClassInfo ci) {
-              return isJndiLookupClass(ci);
+              return isJndiLookupIshClass(ci);
             }
-          })
-          .loadClasses(true);
+          });
 
       final Set<String> resultClassNameSet = new HashSet<String>();
-      for (Class<?> c : culpritClasses) {
-        final String className = c.getCanonicalName();
+      for (ClassInfo ci : JndiLookupIshClassInfos) {
+        final String className = ci.getName();
         resultClassNameSet.add(className);
         logger.log("Detected log4j JndiLookup class: " + className);
       }
@@ -49,9 +48,8 @@ public class JndiLookupClassFinder {
     }
   }
 
-  private static boolean isJndiLookupClass(ClassInfo ci) {
-    return ci.isStandardClass()
-      && !(ci.isSynthetic()
+  private static boolean isJndiLookupIshClass(ClassInfo ci) {
+    return !(ci.isSynthetic()
       || ci.isAbstract()
       || ci.isInnerClass()
       || ci.isArrayClass()

--- a/src/trust/nccgroup/jndibegone/JndiLookupClassFinder.java
+++ b/src/trust/nccgroup/jndibegone/JndiLookupClassFinder.java
@@ -1,0 +1,100 @@
+package trust.nccgroup.jndibegone;
+
+import io.github.classgraph.*;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class JndiLookupClassFinder {
+
+  private static final String DEFAULT_JNDI_LOOKUP_CLASS_NAME = "org.apache.logging.log4j.core.lookup.JndiLookup";
+  private static final String MARKER_FIELD_NAME = "CONTAINER_JNDI_RESOURCE_PATH_PREFIX";
+  private static final String MARKER_METHOD_NAME = "lookup";
+  private static final String STRING_TYPE = "java.lang.String";
+
+  public static Set<String> findJndiLookupClassNames() {
+    final ClassGraph classGraph = new ClassGraph()
+      .ignoreFieldVisibility()
+      .enableMethodInfo()
+      .enableClassInfo();
+    final ScanResult scanResult = classGraph.scan();
+    try {
+      final List<Class<?>> culpritClasses =
+        scanResult
+          .getAllClasses()
+          .filter(new ClassInfoList.ClassInfoFilter() {
+            public boolean accept(ClassInfo ci) {
+              return isJndiLookupClass(ci);
+            }
+          })
+          .loadClasses(true);
+      final Set<String> resultClassNameSet = new HashSet<String>();
+      for (Class<?> c : culpritClasses) {
+        final String className = c.getCanonicalName();
+        resultClassNameSet.add(className);
+        logInfo("Found Log4j2 JndiLookup class: " + className);
+        if (!DEFAULT_JNDI_LOOKUP_CLASS_NAME.equals(className)) {
+          logWarn("Found a class that looks like a renamed Log4j2 JndiLookup: " + className);
+        }
+      }
+      return resultClassNameSet;
+    } finally {
+      scanResult.close();
+    }
+  }
+
+  private static boolean isJndiLookupClass(ClassInfo ci) {
+    return ci.isStandardClass()
+      && !(ci.isSynthetic()
+      || ci.isAbstract()
+      || ci.isInnerClass()
+      || ci.isArrayClass()
+      || ci.isEnum()
+    ) && isClassSignatureMatch(ci);
+  }
+
+  private static boolean isClassSignatureMatch(ClassInfo ci) {
+    return isFieldSignatureMatch(ci.getDeclaredFieldInfo(MARKER_FIELD_NAME))
+      && isMethodSignatureMatch(ci.getDeclaredMethodInfo(MARKER_METHOD_NAME));
+  }
+
+  private static boolean isFieldSignatureMatch(FieldInfo fi) {
+    return fi != null
+      && STRING_TYPE.equals(fi.getTypeDescriptor().toString())
+      && fi.isStatic()
+      && fi.isFinal();
+  }
+
+  private static boolean isMethodSignatureMatch(MethodInfoList methodInfolist) {
+    if (methodInfolist.isEmpty()) {
+      return false;
+    }
+    try {
+      final MethodInfo mi = methodInfolist.getSingleMethod(MARKER_METHOD_NAME);
+      if (mi == null || !STRING_TYPE.equals(mi.getTypeDescriptor().getResultType().toString())) {
+        return false;
+      }
+      final MethodParameterInfo[] parameterInfos = mi.getParameterInfo();
+      return parameterInfos.length == 2
+        && !STRING_TYPE.equals(parameterInfos[0].getTypeDescriptor().toString())
+        && STRING_TYPE.equals(parameterInfos[1].getTypeDescriptor().toString());
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  private static void logWarn(String msg) {
+    doLog("[WARNING] " + msg);
+  }
+
+  private static void logInfo(String msg) {
+    doLog("[INFO] " + msg);
+  }
+
+  private static void doLog(String msg) {
+    System.out.println("[LOG4J_JNDI_BE_GONE]" + msg);
+    // todo: log to a file
+  }
+
+}

--- a/src/trust/nccgroup/jndibegone/Logger.java
+++ b/src/trust/nccgroup/jndibegone/Logger.java
@@ -1,0 +1,55 @@
+package trust.nccgroup.jndibegone;
+
+import java.io.*;
+import java.lang.management.ManagementFactory;
+
+public class Logger {
+
+  private final File logFile;
+
+  public Logger(String logDirPath) {
+    if (logDirPath == null) {
+      this.logFile = null;
+    } else {
+      final File dir = new File(logDirPath);
+      final boolean dirReady = (dir.exists() || dir.mkdirs()) && dir.canWrite();
+
+      File logFile = null;
+      if (dirReady) {
+        try {
+          final String jvmName = ManagementFactory.getRuntimeMXBean().getName();
+          logFile = File.createTempFile("log4j_jndi_be_gone." + jvmName + ".", ".log", dir);
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+      }
+      this.logFile = logFile;
+    }
+  }
+
+  public void log(String msg) {
+    System.err.println("[LOG4J_JNDI_BE_GONE] " + msg);
+
+    if (logFile != null) {
+      PrintWriter writer = null;
+      try {
+        writer = new PrintWriter(new FileWriter(logFile, true));
+        writer.println(msg);
+      } catch (IOException e) {
+        // Just ignore as there is anything we can do about it.
+      } finally {
+        closeQuietly(writer);
+      }
+    }
+  }
+
+  private static void closeQuietly(Writer writer) {
+    if (writer != null) {
+      try {
+        writer.close();
+      } catch (IOException e) {
+        // ignore
+      }
+    }
+  }
+}

--- a/src/trust/nccgroup/jndibegone/PreMain.java
+++ b/src/trust/nccgroup/jndibegone/PreMain.java
@@ -24,6 +24,6 @@ import java.lang.instrument.Instrumentation;
 public class PreMain {
 
   public static void premain(String args, Instrumentation inst) {
-    Agent.load(inst);
+    Agent.load(args, inst);
   }
 }

--- a/src/trust/nccgroup/jndibegone/hooks/JndiLookup__lookup.java
+++ b/src/trust/nccgroup/jndibegone/hooks/JndiLookup__lookup.java
@@ -16,7 +16,6 @@ limitations under the License.
 
 package trust.nccgroup.jndibegone.hooks;
 
-import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.AsmVisitorWrapper;
@@ -27,10 +26,14 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.utility.JavaModule;
 
 import java.lang.instrument.Instrumentation;
+import java.util.Set;
+
+import static trust.nccgroup.jndibegone.JndiLookupClassFinder.findJndiLookupClassNames;
 
 public class JndiLookup__lookup {
 
   private static final String TAG = "JndiLookup__lookup";
+  private static final Set<String> jndiLookupClassNames = findJndiLookupClassNames();
 
   @Advice.OnMethodEnter(inline = true, skipOn = Advice.OnNonDefaultValue.class)
   static String enter(@Advice.Argument(readOnly = true, value = 1) String key) {
@@ -54,7 +57,7 @@ public class JndiLookup__lookup {
     .ignore(ElementMatchers.none())
     .type(new ElementMatcher<TypeDescription>() {
       public boolean matches(TypeDescription target) {
-        return "org.apache.logging.log4j.core.lookup.JndiLookup".equals(target.getCanonicalName());
+        return jndiLookupClassNames.contains(target.getCanonicalName());
       }
     })
     .transform(new AgentBuilder.Transformer() {


### PR DESCRIPTION
- Utilize a class scanner to detect `JndiLookup` classes that have been renamed.
- Add an optional logging to a file (controlled by an agent argument). The log file is unique for a host and contains a running jvm PID in its name.
- Update README accordingly