### PR TITLE
Add shading to bytebuddy to avoid dependency conflicts on classpath

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-build/
-.gradle/
+build/*
+.gradle/*
+.idea/*

--- a/AUTHORS
+++ b/AUTHORS
@@ -10,5 +10,5 @@ Maintainers:
 
 Contributors:
 -------------
-
+- Alex Hatzenbuhler
 

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ artifacts {
 shadowJar {
     // removes -all from the build
     classifier = 'standalone'
-    relocate 'net.bytebuddy', 'log4jjndibegone.bytebuddy'
+    relocate 'net.bytebuddy', 'trust.nccgroup.jndibegone.bytebuddy'
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-  id 'com.github.johnrengelman.shadow' version '7.1.0'
-  id 'java'
-  id 'maven-publish'
+    id 'com.github.johnrengelman.shadow' version '7.1.0'
+    id 'java'
+    id 'maven-publish'
 }
 
 group = 'trust.nccgroup'
@@ -11,62 +11,61 @@ sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
 repositories {
-  mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-  implementation group: 'net.bytebuddy', name: 'byte-buddy', version: '[1.12.0, 1.13)'
+    implementation group: 'net.bytebuddy', name: 'byte-buddy', version: '[1.12.0, 1.13)'
 }
 
 sourceSets {
-  main {
-    java {
-      srcDirs = ['./src']
-    }
+    main {
+        java {
+            srcDirs = ['./src']
+        }
 
-    resources {
-      srcDirs = ['./res']
+        resources {
+            srcDirs = ['./res']
+        }
     }
-  }
 }
 
 jar {
-  manifest {
-    attributes (
-      "Manifest-Version": "1.0",
-      "Can-Redefine-Classes": "true",
-      "Can-Retransform-Classes": "true",
-      "Can-Set-Native-Method-Prefix": "true",
-      "Premain-Class": "trust.nccgroup.jndibegone.PreMain",
-      "Agent-Class": "trust.nccgroup.jndibegone.AgentMain"
-    )
-  }
+    manifest {
+        attributes(
+            "Manifest-Version": "1.0",
+            "Can-Redefine-Classes": "true",
+            "Can-Retransform-Classes": "true",
+            "Can-Set-Native-Method-Prefix": "true",
+            "Premain-Class": "trust.nccgroup.jndibegone.PreMain",
+            "Agent-Class": "trust.nccgroup.jndibegone.AgentMain"
+        )
+    }
 }
 
-
 compileJava {
-  options.compilerArgs << '-Xlint:unchecked'
+    options.compilerArgs << '-Xlint:unchecked'
 }
 
 task sourceJar(type: Jar) {
-  from sourceSets.main.allJava
-  classifier = 'sources'
+    from sourceSets.main.allJava
+    classifier = 'sources'
 }
 
 task javadocJar(type: Jar) {
-  from javadoc
-  classifier = 'javadoc'
+    from javadoc
+    classifier = 'javadoc'
 }
 
 artifacts {
-  archives javadocJar, sourceJar
+    archives javadocJar, sourceJar
 }
 
 shadowJar {
-  // removes -all from the build
-  classifier = 'standalone'
+    // removes -all from the build
+    classifier = 'standalone'
+    relocate 'net.bytebuddy', 'log4jjndibegone.bytebuddy'
 }
-
 
 publishing {
     publications {
@@ -74,8 +73,8 @@ publishing {
             from components.java
             pom {
                 name = 'log4j-jndi-be-gone'
-                description = 
-                url = 'https://github.com/nccgroup/log4j-jndi-be-gone'
+                description =
+                    url = 'https://github.com/nccgroup/log4j-jndi-be-gone'
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I'm far from an expert here but I think this should resolve #6, which has some additional information on the bytebuddy repo here: https://github.com/raphw/byte-buddy/issues/1179.

The issue that I seem to be having is classpath conflicts with an older version of bytebuddy bundled in applications. I believe that using the `relocate` ability of shadowjar will avoid this classpath conflict.

## Main Change
- Add a `relocate` to the bytebuddy dependency to avoid conflicts on the classpath for users of this library


## Small Changes
- Update the gradle wrapper to `7.3.3`
- Add `.editorconfig` for some consistency in tab sizes on gradle